### PR TITLE
Set UITableViewAutomaticDimension for cells

### DIFF
--- a/Example/EventBottle/ViewController.swift
+++ b/Example/EventBottle/ViewController.swift
@@ -26,6 +26,7 @@ class ViewController: UIViewController {
 
     @IBAction func didTapEvent3Button(_: Any) {
         event3count += 1
-        eventDataStore.putEvent(["event": "event3", "allCount": event1count + event2count + event3count], labels: ["event", "test", "count", "all"])
+        let veryLongBody = (0..<100).map { _ in "0" }.joined()
+        eventDataStore.putEvent(["event": "event3", "allCount": event1count + event2count + event3count, "body": veryLongBody], labels: ["event", "test", "count", "all"])
     }
 }

--- a/Sources/EventBottle/EventViewer/EventBottleViewController.swift
+++ b/Sources/EventBottle/EventViewer/EventBottleViewController.swift
@@ -9,6 +9,7 @@ public class EventBottleViewController: UIViewController, UITableViewDataSource,
     private let errorMessageLabel = UILabel()
     private let errorMessageBackgroundView = UIView()
     private let searchController = UISearchController(searchResultsController: nil)
+    private let defaultRowHeihgt: CGFloat = 44
 
     private var isLoading = false {
         didSet {
@@ -76,6 +77,8 @@ public class EventBottleViewController: UIViewController, UITableViewDataSource,
         tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor).isActive = true
         tableView.leadingAnchor.constraint(equalTo: view.leadingAnchor).isActive = true
         tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor).isActive = true
+        tableView.estimatedRowHeight = defaultRowHeihgt
+        tableView.rowHeight = UITableViewAutomaticDimension
 
         tableView.register(EventCell.self, forCellReuseIdentifier: EventCell.defaultIdentifier)
 


### PR DESCRIPTION
# Context

On iOS 10 or earlier, tableview cells' heights are not set automatically.
So long payloads are dropped from display.

|Before|After|
|------------|-------------|
|![simulator screen shot - iphone se - 2018-02-07 at 18 26 19](https://user-images.githubusercontent.com/147051/35908597-8621cb6c-0c34-11e8-82a9-8f271416af44.png)|![simulator screen shot - iphone se - 2018-02-07 at 18 25 20](https://user-images.githubusercontent.com/147051/35908599-878c5b70-0c34-11e8-8bcc-b88c71f76665.png)|