### PR TITLE
Fix Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 
 let package = Package(
     name: "EventBottle",
-    platforms: [.iOS(.v9)],
+    platforms: [.iOS(.v10)],
     products: [
         .library(
             name: "EventBottle",

--- a/Package.swift
+++ b/Package.swift
@@ -1,9 +1,10 @@
-// swift-tools-version:4.0
+// swift-tools-version:5.0
 
 import PackageDescription
 
 let package = Package(
     name: "EventBottle",
+    platforms: [.iOS(.v9)],
     products: [
         .library(
             name: "EventBottle",
@@ -13,8 +14,7 @@ let package = Package(
     targets: [
         .target(
             name: "EventBottle",
-            dependencies: [],
-            exclude: ["EventViewer"]
+            dependencies: []
         ),
         .testTarget(
             name: "EventBottleTests",


### PR DESCRIPTION
- specified platform
  - chose iOS10 as a minimum version because `obscuresBackgroundDuringPresentation` is available iOS9.1 or later
- changed not to exclude `EventViewer` to make `EventBottleViewController` available